### PR TITLE
feat(RM-24): Add PanelHereMention functionality and integrate into Database

### DIFF
--- a/database.go
+++ b/database.go
@@ -61,6 +61,7 @@ type Database struct {
 	PanelRoleMentions              *PanelRoleMentions
 	PanelTeams                     *PanelTeamsTable
 	PanelUserMention               *PanelUserMention
+	PanelHereMention               *PanelHereMention
 	Participants                   *ParticipantTable
 	PatreonEntitlements            *PatreonEntitlements
 	Permissions                    *Permissions
@@ -149,6 +150,7 @@ func NewDatabase(pool *pgxpool.Pool) *Database {
 		PanelRoleMentions:              newPanelRoleMentions(pool),
 		PanelTeams:                     newPanelTeamsTable(pool),
 		PanelUserMention:               newPanelUserMention(pool),
+		PanelHereMention:               newPanelHereMention(pool),
 		Participants:                   newParticipantTable(pool),
 		PatreonEntitlements:            newPatreonEntitlements(pool),
 		Permissions:                    newPermissions(pool),
@@ -256,6 +258,7 @@ func (d *Database) CreateTables(ctx context.Context, pool *pgxpool.Pool) {
 		d.MultiPanelTargets,       // must be created after panels table
 		d.PanelRoleMentions,
 		d.PanelUserMention,
+		d.PanelHereMention,
 		d.PatreonEntitlements,
 		d.Permissions,
 		d.PremiumGuilds,

--- a/panelmentionhere.go
+++ b/panelmentionhere.go
@@ -1,0 +1,60 @@
+package database
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type PanelHereMention struct {
+	*pgxpool.Pool
+}
+
+func newPanelHereMention(db *pgxpool.Pool) *PanelHereMention {
+	return &PanelHereMention{
+		db,
+	}
+}
+
+func (p PanelHereMention) Schema() string {
+	return `
+CREATE TABLE IF NOT EXISTS panel_here_mentions(
+	"panel_id" int NOT NULL,
+	"should_mention_here" bool NOT NULL,
+	FOREIGN KEY("panel_id") REFERENCES panels("panel_id") ON DELETE CASCADE ON UPDATE CASCADE,
+	PRIMARY KEY("panel_id")
+);
+`
+}
+
+func (p *PanelHereMention) ShouldMentionHere(ctx context.Context, panelId int) (shouldMention bool, e error) {
+	query := `SELECT "should_mention_here" from panel_here_mentions WHERE "panel_id"=$1;`
+
+	if err := p.QueryRow(ctx, query, panelId).Scan(&shouldMention); err != nil && err != pgx.ErrNoRows {
+		e = err
+	}
+
+	return
+}
+
+func (p *PanelHereMention) Set(ctx context.Context, panelId int, shouldMentionHere bool) error {
+	tx, err := p.Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer tx.Rollback(ctx)
+
+	if err := p.SetWithTx(ctx, tx, panelId, shouldMentionHere); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (p *PanelHereMention) SetWithTx(ctx context.Context, tx pgx.Tx, panelId int, shouldMentionHere bool) (err error) {
+	query := `INSERT INTO panel_here_mentions("panel_id", "should_mention_here") VALUES($1, $2) ON CONFLICT("panel_id") DO UPDATE SET "should_mention_here" = $2;`
+	_, err = tx.Exec(ctx, query, panelId, shouldMentionHere)
+	return
+}


### PR DESCRIPTION
This pull request introduces a new feature to handle "here" mentions in panels by adding a new `PanelHereMention` struct and its associated methods. The changes involve updates to the `database.go` file and the addition of a new file `panelmentionhere.go`.

### Key changes:

**Database schema changes:**
* Added a new field `PanelHereMention` to the `Database` struct in `database.go` to manage "here" mentions.
* Updated the `NewDatabase` function to initialize the new `PanelHereMention` field.
* Modified the `CreateTables` method to include the new `PanelHereMention` table creation.

**New functionality:**
* Created a new file `panelmentionhere.go` that defines the `PanelHereMention` struct and its methods for managing "here" mentions in panels. This includes methods for creating the table schema, checking if a panel should mention "here", and setting the "here" mention status.