### PR TITLE
feat(RM-40): MessageID & ChannelID as nullable

### DIFF
--- a/panels.go
+++ b/panels.go
@@ -12,8 +12,8 @@ import (
 // ALTER TABLE panels ADD COLUMN use_threads bool NOT NULL DEFAULT false;
 type Panel struct {
 	PanelId             int     `json:"panel_id"`
-	MessageId           uint64  `json:"message_id,string"`
-	ChannelId           uint64  `json:"channel_id,string"`
+	MessageId           *uint64 `json:"message_id,string"`
+	ChannelId           *uint64 `json:"channel_id,string"`
 	GuildId             uint64  `json:"guild_id,string"`
 	Title               string  `json:"title"`
 	Content             string  `json:"content"`
@@ -59,8 +59,8 @@ func (p PanelTable) Schema() string {
 	return `
 CREATE TABLE IF NOT EXISTS panels(
 	"panel_id" SERIAL NOT NULL UNIQUE,
-	"message_id" int8 NOT NULL UNIQUE,
-	"channel_id" int8 NOT NULL,
+	"message_id" int8 DEFAULT NULL UNIQUE,
+	"channel_id" int8 DEFAULT NULL,
 	"guild_id" int8 NOT NULL,
 	"title" varchar(255) NOT NULL,
 	"content" text NOT NULL,
@@ -728,7 +728,7 @@ UPDATE panels
 	return err
 }
 
-func (p *PanelTable) UpdateMessageId(ctx context.Context, panelId int, messageId uint64) (err error) {
+func (p *PanelTable) UpdateMessageId(ctx context.Context, panelId int, messageId *uint64) (err error) {
 	query := `
 UPDATE panels
 SET "message_id" = $1
@@ -736,6 +736,17 @@ WHERE "panel_id" = $2;
 `
 
 	_, err = p.Exec(ctx, query, messageId, panelId)
+	return
+}
+
+func (p *PanelTable) UpdateChannelId(ctx context.Context, panelId int, channelId *uint64) (err error) {
+	query := `
+UPDATE panels
+SET "channel_id" = $1
+WHERE "panel_id" = $2;
+`
+
+	_, err = p.Exec(ctx, query, channelId, panelId)
 	return
 }
 


### PR DESCRIPTION
This pull request introduces changes to the `panels.go` file, primarily to allow `message_id` and `channel_id` fields to be nullable, improving flexibility in handling panel data. Key updates include modifying the schema, struct definitions, and related methods to support nullable values.

### Schema and struct updates:
* Changed the `message_id` and `channel_id` fields in the `Panel` struct to be pointers (`*uint64`) to allow null values. ([`panels.goL14-R15`](diffhunk://#diff-75e25e8ac51952c6c506a1a9c20cbe779173e308b5396d0b6517c7583ee45d20L14-R15))
* Updated the database schema for the `panels` table to make `message_id` and `channel_id` nullable by setting their default to `NULL`. ([`panels.goL59-R60`](diffhunk://#diff-75e25e8ac51952c6c506a1a9c20cbe779173e308b5396d0b6517c7583ee45d20L59-R60))

### Method updates:
* Modified `UpdateMessageId` to accept a pointer (`*uint64`) for `message_id` to handle nullable values. ([`panels.goL601-R601`](diffhunk://#diff-75e25e8ac51952c6c506a1a9c20cbe779173e308b5396d0b6517c7583ee45d20L601-R601))
* Added a new method `UpdateChannelId` to update the `channel_id` field, also supporting nullable values. ([`panels.goR612-R622`](diffhunk://#diff-75e25e8ac51952c6c506a1a9c20cbe779173e308b5396d0b6517c7583ee45d20R612-R622))

### Migration:
* This pull request does require an update to the database to allow nullable fields (channel_id & message_id)
  ```sql
  ALTER TABLE panels ALTER COLUMN "channel_id" DROP NOT NULL;
  ALTER TABLE panels ALTER COLUMN "message_id" DROP NOT NULL;
  ```
  
## Notes

This PR was originally created in May, and was later updated; original changes can be found by comparing commits [17762cd7d39ae3c02a4746978cff5021a749f80b & e113c4330d33cc2cc885a240c0dd4427e052eb29](https://github.com/DanPlayz0/tbv2-database/compare/17762cd7d39ae3c02a4746978cff5021a749f80b..e113c4330d33cc2cc885a240c0dd4427e052eb29)