### PR TITLE
Add GetReason methods to blacklist structs

### DIFF
--- a/globalblacklist.go
+++ b/globalblacklist.go
@@ -64,3 +64,9 @@ func (b *GlobalBlacklist) Delete(ctx context.Context, userId uint64) (err error)
 	_, err = b.Exec(ctx, `DELETE FROM global_blacklist WHERE "user_id" = $1;`, userId)
 	return
 }
+
+func (b *GlobalBlacklist) GetReason(ctx context.Context, userId uint64) (reason string, err error) {
+	query := `SELECT COALESCE(reason, '') FROM global_blacklist WHERE "user_id"=$1;`
+	err = b.QueryRow(ctx, query, userId).Scan(&reason)
+	return
+}

--- a/serverblacklist.go
+++ b/serverblacklist.go
@@ -67,3 +67,9 @@ func (b *ServerBlacklist) Delete(ctx context.Context, guildId uint64) (err error
 	_, err = b.Exec(ctx, `DELETE FROM server_blacklist WHERE "guild_id" = $1;`, guildId)
 	return
 }
+
+func (b *ServerBlacklist) GetReason(ctx context.Context, guildId uint64) (reason string, err error) {
+	query := `SELECT COALESCE(reason, '') FROM server_blacklist WHERE "guild_id"=$1;`
+	err = b.QueryRow(ctx, query, guildId).Scan(&reason)
+	return
+}


### PR DESCRIPTION
Introduces GetReason methods for both GlobalBlacklist and ServerBlacklist to retrieve the reason field for a given user or guild. This allows querying the reason for a blacklist entry directly from the database.

For https://github.com/TicketsBot-cloud/worker/pull/30