### PR TITLE
RM-227: Fix patreon grace period

### DIFF
--- a/entitlements.go
+++ b/entitlements.go
@@ -46,6 +46,9 @@ var (
 
 	//go:embed sql/entitlements/increase_expiry.sql
 	entitlementsIncreaseExpiry string
+
+	//go:embed sql/entitlements/update_expires_at.sql
+	entitlementsUpdateExpiresAt string
 )
 
 func newEntitlementsTable(db *pgxpool.Pool) *Entitlements {
@@ -253,5 +256,10 @@ func (e *Entitlements) ListAllUserSubscriptions(ctx context.Context, gracePeriod
 
 func (e *Entitlements) IncreaseExpiry(ctx context.Context, tx pgx.Tx, guildId, userId *uint64, skuId uuid.UUID, source model.EntitlementSource, duration time.Duration) error {
 	_, err := tx.Exec(ctx, entitlementsIncreaseExpiry, guildId, userId, skuId, source, duration)
+	return err
+}
+
+func (e *Entitlements) SetExpiresAt(ctx context.Context, tx pgx.Tx, id uuid.UUID, expiresAt *time.Time) error {
+	_, err := tx.Exec(ctx, entitlementsUpdateExpiresAt, id, expiresAt)
 	return err
 }

--- a/sql/entitlements/update_expires_at.sql
+++ b/sql/entitlements/update_expires_at.sql
@@ -1,0 +1,3 @@
+UPDATE entitlements
+SET expires_at = $2
+WHERE id = $1;


### PR DESCRIPTION
RM-227
Introduces the SetExpiresAt method in the Entitlements struct to allow updating the expires_at field for a given entitlement. Adds the corresponding SQL file and embeds it for use in the method.

For: https://github.com/TicketsBot-cloud/patreon-db-sync/pull/2