### PR TITLE
RM-243: Add team permissions

### DIFF
--- a/auditlog.go
+++ b/auditlog.go
@@ -40,6 +40,7 @@ const (
 
 	AuditActionTeamCreate AuditActionType = 60
 	AuditActionTeamDelete AuditActionType = 61
+	AuditActionTeamUpdate AuditActionType = 62
 
 	AuditActionTeamMemberAdd    AuditActionType = 65
 	AuditActionTeamMemberRemove AuditActionType = 66

--- a/database.go
+++ b/database.go
@@ -84,6 +84,7 @@ type Database struct {
 	SubscriptionSkus               *SubscriptionSkus
 	SupportTeam                    *SupportTeamTable
 	SupportTeamMembers             *SupportTeamMembersTable
+	SupportTeamPermissions         *SupportTeamPermissionsTable
 	SupportTeamRoles               *SupportTeamRolesTable
 	Tag                            *TagsTable
 	TicketClaims                   *TicketClaims
@@ -183,6 +184,7 @@ func NewDatabase(pool *pgxpool.Pool) *Database {
 		SubscriptionSkus:               newSubscriptionSkusTable(pool),
 		SupportTeam:                    newSupportTeamTable(pool),
 		SupportTeamMembers:             newSupportTeamMembersTable(pool),
+		SupportTeamPermissions:         newSupportTeamPermissionsTable(pool),
 		SupportTeamRoles:               newSupportTeamRolesTable(pool),
 		Tag:                            newTag(pool),
 		TicketClaims:                   newTicketClaims(pool),
@@ -298,7 +300,8 @@ func (d *Database) CreateTables(ctx context.Context, pool *pgxpool.Pool) {
 		d.SupportTeam,
 		d.SupportTeamMembers,
 		d.SupportTeamRoles,
-		d.PanelTeams, // Must be created after panels & support teams tables
+		d.SupportTeamPermissions, // must be created after support_team table
+		d.PanelTeams,             // Must be created after panels & support teams tables
 		d.Tag,
 		d.TicketLimit,
 		d.TicketPermissions,

--- a/supportteampermissions.go
+++ b/supportteampermissions.go
@@ -1,0 +1,128 @@
+package database
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type SupportTeamPermissions struct {
+	SendMessages           bool `json:"send_messages"`
+	EmbedLinks             bool `json:"embed_links"`
+	AttachFiles            bool `json:"attach_files"`
+	AddReactions           bool `json:"add_reactions"`
+	SendVoiceMessages      bool `json:"send_voice_messages"`
+	SendTTSMessages        bool `json:"send_tts_messages"`
+	UseApplicationCommands bool `json:"use_application_commands"`
+	MentionEveryone        bool `json:"mention_everyone"`
+}
+
+type SupportTeamPermissionsTable struct {
+	*pgxpool.Pool
+}
+
+func newSupportTeamPermissionsTable(db *pgxpool.Pool) *SupportTeamPermissionsTable {
+	return &SupportTeamPermissionsTable{
+		db,
+	}
+}
+
+func (c SupportTeamPermissionsTable) Schema() string {
+	return `
+CREATE TABLE IF NOT EXISTS support_team_permissions(
+	"team_id"                 int  NOT NULL,
+	"send_messages"           bool NOT NULL DEFAULT 't',
+	"embed_links"             bool NOT NULL DEFAULT 't',
+	"attach_files"            bool NOT NULL DEFAULT 't',
+	"add_reactions"           bool NOT NULL DEFAULT 't',
+	"send_voice_messages"     bool NOT NULL DEFAULT 't',
+	"send_tts_messages"       bool NOT NULL DEFAULT 't',
+	"use_application_commands" bool NOT NULL DEFAULT 't',
+	"mention_everyone"        bool NOT NULL DEFAULT 'f',
+	FOREIGN KEY("team_id") REFERENCES support_team("id") ON DELETE CASCADE ON UPDATE CASCADE,
+	PRIMARY KEY("team_id")
+);
+`
+}
+
+func defaultSupportTeamPermissions() SupportTeamPermissions {
+	return SupportTeamPermissions{
+		SendMessages:           true,
+		EmbedLinks:             true,
+		AttachFiles:            true,
+		AddReactions:           true,
+		SendVoiceMessages:      true,
+		SendTTSMessages:        true,
+		UseApplicationCommands: true,
+		MentionEveryone:        false,
+	}
+}
+
+func (c *SupportTeamPermissionsTable) Get(ctx context.Context, teamId int) (SupportTeamPermissions, error) {
+	query := `
+SELECT "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone"
+FROM support_team_permissions
+WHERE "team_id" = $1;`
+
+	var perms SupportTeamPermissions
+	err := c.QueryRow(ctx, query, teamId).Scan(
+		&perms.SendMessages,
+		&perms.EmbedLinks,
+		&perms.AttachFiles,
+		&perms.AddReactions,
+		&perms.SendVoiceMessages,
+		&perms.SendTTSMessages,
+		&perms.UseApplicationCommands,
+		&perms.MentionEveryone,
+	)
+
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return defaultSupportTeamPermissions(), nil
+		}
+		return SupportTeamPermissions{}, err
+	}
+
+	return perms, nil
+}
+
+func (c *SupportTeamPermissionsTable) Set(ctx context.Context, teamId int, perms SupportTeamPermissions) error {
+	query := `
+INSERT INTO support_team_permissions("team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone")
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT("team_id") DO UPDATE SET "send_messages" = $2, "embed_links" = $3, "attach_files" = $4, "add_reactions" = $5, "send_voice_messages" = $6, "send_tts_messages" = $7, "use_application_commands" = $8, "mention_everyone" = $9;`
+
+	_, err := c.Exec(ctx, query, teamId, perms.SendMessages, perms.EmbedLinks, perms.AttachFiles, perms.AddReactions, perms.SendVoiceMessages, perms.SendTTSMessages, perms.UseApplicationCommands, perms.MentionEveryone)
+	return err
+}
+
+func (c *SupportTeamPermissionsTable) GetForTeams(ctx context.Context, teamIds []int) (map[int]SupportTeamPermissions, error) {
+	result := make(map[int]SupportTeamPermissions)
+
+	if len(teamIds) == 0 {
+		return result, nil
+	}
+
+	query := `
+SELECT "team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone"
+FROM support_team_permissions
+WHERE "team_id" = ANY($1);`
+
+	rows, err := c.Query(ctx, query, teamIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var teamId int
+		var perms SupportTeamPermissions
+		if err := rows.Scan(&teamId, &perms.SendMessages, &perms.EmbedLinks, &perms.AttachFiles, &perms.AddReactions, &perms.SendVoiceMessages, &perms.SendTTSMessages, &perms.UseApplicationCommands, &perms.MentionEveryone); err != nil {
+			return nil, err
+		}
+		result[teamId] = perms
+	}
+
+	return result, rows.Err()
+}

--- a/supportteampermissions.go
+++ b/supportteampermissions.go
@@ -8,16 +8,16 @@ import (
 )
 
 type SupportTeamPermissions struct {
+	AddReactions           bool `json:"add_reactions"`
 	SendMessages           bool `json:"send_messages"`
+	SendTTSMessages        bool `json:"send_tts_messages"`
 	EmbedLinks             bool `json:"embed_links"`
 	AttachFiles            bool `json:"attach_files"`
-	AddReactions           bool `json:"add_reactions"`
-	SendVoiceMessages      bool `json:"send_voice_messages"`
-	SendTTSMessages        bool `json:"send_tts_messages"`
-	UseApplicationCommands bool `json:"use_application_commands"`
 	MentionEveryone        bool `json:"mention_everyone"`
 	UseExternalEmojis      bool `json:"use_external_emojis"`
+	UseApplicationCommands bool `json:"use_application_commands"`
 	UseExternalStickers    bool `json:"use_external_stickers"`
+	SendVoiceMessages      bool `json:"send_voice_messages"`
 }
 
 type SupportTeamPermissionsTable struct {
@@ -34,16 +34,16 @@ func (c SupportTeamPermissionsTable) Schema() string {
 	return `
 CREATE TABLE IF NOT EXISTS support_team_permissions(
 	"team_id"                 int  NOT NULL,
-	"send_messages"           bool NOT NULL DEFAULT 't',
-	"embed_links"             bool NOT NULL DEFAULT 't',
-	"attach_files"            bool NOT NULL DEFAULT 't',
-	"add_reactions"           bool NOT NULL DEFAULT 't',
-	"send_voice_messages"     bool NOT NULL DEFAULT 't',
-	"send_tts_messages"       bool NOT NULL DEFAULT 't',
-	"use_application_commands" bool NOT NULL DEFAULT 't',
+	"add_reactions"            bool NOT NULL DEFAULT 't',
+	"send_messages"            bool NOT NULL DEFAULT 't',
+	"send_tts_messages"        bool NOT NULL DEFAULT 't',
+	"embed_links"              bool NOT NULL DEFAULT 't',
+	"attach_files"             bool NOT NULL DEFAULT 't',
 	"mention_everyone"         bool NOT NULL DEFAULT 'f',
 	"use_external_emojis"      bool NOT NULL DEFAULT 't',
+	"use_application_commands" bool NOT NULL DEFAULT 't',
 	"use_external_stickers"    bool NOT NULL DEFAULT 't',
+	"send_voice_messages"      bool NOT NULL DEFAULT 't',
 	FOREIGN KEY("team_id") REFERENCES support_team("id") ON DELETE CASCADE ON UPDATE CASCADE,
 	PRIMARY KEY("team_id")
 );
@@ -52,37 +52,37 @@ CREATE TABLE IF NOT EXISTS support_team_permissions(
 
 func defaultSupportTeamPermissions() SupportTeamPermissions {
 	return SupportTeamPermissions{
+		AddReactions:           true,
 		SendMessages:           true,
+		SendTTSMessages:        true,
 		EmbedLinks:             true,
 		AttachFiles:            true,
-		AddReactions:           true,
-		SendVoiceMessages:      true,
-		SendTTSMessages:        true,
-		UseApplicationCommands: true,
 		MentionEveryone:        false,
 		UseExternalEmojis:      true,
+		UseApplicationCommands: true,
 		UseExternalStickers:    true,
+		SendVoiceMessages:      true,
 	}
 }
 
 func (c *SupportTeamPermissionsTable) Get(ctx context.Context, teamId int) (SupportTeamPermissions, error) {
 	query := `
-SELECT "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone", "use_external_emojis", "use_external_stickers"
+SELECT "add_reactions", "send_messages", "send_tts_messages", "embed_links", "attach_files", "mention_everyone", "use_external_emojis", "use_application_commands", "use_external_stickers", "send_voice_messages"
 FROM support_team_permissions
 WHERE "team_id" = $1;`
 
 	var perms SupportTeamPermissions
 	err := c.QueryRow(ctx, query, teamId).Scan(
+		&perms.AddReactions,
 		&perms.SendMessages,
+		&perms.SendTTSMessages,
 		&perms.EmbedLinks,
 		&perms.AttachFiles,
-		&perms.AddReactions,
-		&perms.SendVoiceMessages,
-		&perms.SendTTSMessages,
-		&perms.UseApplicationCommands,
 		&perms.MentionEveryone,
 		&perms.UseExternalEmojis,
+		&perms.UseApplicationCommands,
 		&perms.UseExternalStickers,
+		&perms.SendVoiceMessages,
 	)
 
 	if err != nil {
@@ -97,11 +97,11 @@ WHERE "team_id" = $1;`
 
 func (c *SupportTeamPermissionsTable) Set(ctx context.Context, teamId int, perms SupportTeamPermissions) error {
 	query := `
-INSERT INTO support_team_permissions("team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone", "use_external_emojis", "use_external_stickers")
+INSERT INTO support_team_permissions("team_id", "add_reactions", "send_messages", "send_tts_messages", "embed_links", "attach_files", "mention_everyone", "use_external_emojis", "use_application_commands", "use_external_stickers", "send_voice_messages")
 VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-ON CONFLICT("team_id") DO UPDATE SET "send_messages" = $2, "embed_links" = $3, "attach_files" = $4, "add_reactions" = $5, "send_voice_messages" = $6, "send_tts_messages" = $7, "use_application_commands" = $8, "mention_everyone" = $9, "use_external_emojis" = $10, "use_external_stickers" = $11;`
+ON CONFLICT("team_id") DO UPDATE SET "add_reactions" = $2, "send_messages" = $3, "send_tts_messages" = $4, "embed_links" = $5, "attach_files" = $6, "mention_everyone" = $7, "use_external_emojis" = $8, "use_application_commands" = $9, "use_external_stickers" = $10, "send_voice_messages" = $11;`
 
-	_, err := c.Exec(ctx, query, teamId, perms.SendMessages, perms.EmbedLinks, perms.AttachFiles, perms.AddReactions, perms.SendVoiceMessages, perms.SendTTSMessages, perms.UseApplicationCommands, perms.MentionEveryone, perms.UseExternalEmojis, perms.UseExternalStickers)
+	_, err := c.Exec(ctx, query, teamId, perms.AddReactions, perms.SendMessages, perms.SendTTSMessages, perms.EmbedLinks, perms.AttachFiles, perms.MentionEveryone, perms.UseExternalEmojis, perms.UseApplicationCommands, perms.UseExternalStickers, perms.SendVoiceMessages)
 	return err
 }
 
@@ -113,7 +113,7 @@ func (c *SupportTeamPermissionsTable) GetForTeams(ctx context.Context, teamIds [
 	}
 
 	query := `
-SELECT "team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone", "use_external_emojis", "use_external_stickers"
+SELECT "team_id", "add_reactions", "send_messages", "send_tts_messages", "embed_links", "attach_files", "mention_everyone", "use_external_emojis", "use_application_commands", "use_external_stickers", "send_voice_messages"
 FROM support_team_permissions
 WHERE "team_id" = ANY($1);`
 
@@ -126,7 +126,7 @@ WHERE "team_id" = ANY($1);`
 	for rows.Next() {
 		var teamId int
 		var perms SupportTeamPermissions
-		if err := rows.Scan(&teamId, &perms.SendMessages, &perms.EmbedLinks, &perms.AttachFiles, &perms.AddReactions, &perms.SendVoiceMessages, &perms.SendTTSMessages, &perms.UseApplicationCommands, &perms.MentionEveryone, &perms.UseExternalEmojis, &perms.UseExternalStickers); err != nil {
+		if err := rows.Scan(&teamId, &perms.AddReactions, &perms.SendMessages, &perms.SendTTSMessages, &perms.EmbedLinks, &perms.AttachFiles, &perms.MentionEveryone, &perms.UseExternalEmojis, &perms.UseApplicationCommands, &perms.UseExternalStickers, &perms.SendVoiceMessages); err != nil {
 			return nil, err
 		}
 		result[teamId] = perms

--- a/supportteampermissions.go
+++ b/supportteampermissions.go
@@ -16,6 +16,8 @@ type SupportTeamPermissions struct {
 	SendTTSMessages        bool `json:"send_tts_messages"`
 	UseApplicationCommands bool `json:"use_application_commands"`
 	MentionEveryone        bool `json:"mention_everyone"`
+	UseExternalEmojis      bool `json:"use_external_emojis"`
+	UseExternalStickers    bool `json:"use_external_stickers"`
 }
 
 type SupportTeamPermissionsTable struct {
@@ -39,7 +41,9 @@ CREATE TABLE IF NOT EXISTS support_team_permissions(
 	"send_voice_messages"     bool NOT NULL DEFAULT 't',
 	"send_tts_messages"       bool NOT NULL DEFAULT 't',
 	"use_application_commands" bool NOT NULL DEFAULT 't',
-	"mention_everyone"        bool NOT NULL DEFAULT 'f',
+	"mention_everyone"         bool NOT NULL DEFAULT 'f',
+	"use_external_emojis"      bool NOT NULL DEFAULT 't',
+	"use_external_stickers"    bool NOT NULL DEFAULT 't',
 	FOREIGN KEY("team_id") REFERENCES support_team("id") ON DELETE CASCADE ON UPDATE CASCADE,
 	PRIMARY KEY("team_id")
 );
@@ -56,12 +60,14 @@ func defaultSupportTeamPermissions() SupportTeamPermissions {
 		SendTTSMessages:        true,
 		UseApplicationCommands: true,
 		MentionEveryone:        false,
+		UseExternalEmojis:      true,
+		UseExternalStickers:    true,
 	}
 }
 
 func (c *SupportTeamPermissionsTable) Get(ctx context.Context, teamId int) (SupportTeamPermissions, error) {
 	query := `
-SELECT "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone"
+SELECT "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone", "use_external_emojis", "use_external_stickers"
 FROM support_team_permissions
 WHERE "team_id" = $1;`
 
@@ -75,6 +81,8 @@ WHERE "team_id" = $1;`
 		&perms.SendTTSMessages,
 		&perms.UseApplicationCommands,
 		&perms.MentionEveryone,
+		&perms.UseExternalEmojis,
+		&perms.UseExternalStickers,
 	)
 
 	if err != nil {
@@ -89,11 +97,11 @@ WHERE "team_id" = $1;`
 
 func (c *SupportTeamPermissionsTable) Set(ctx context.Context, teamId int, perms SupportTeamPermissions) error {
 	query := `
-INSERT INTO support_team_permissions("team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone")
-VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT("team_id") DO UPDATE SET "send_messages" = $2, "embed_links" = $3, "attach_files" = $4, "add_reactions" = $5, "send_voice_messages" = $6, "send_tts_messages" = $7, "use_application_commands" = $8, "mention_everyone" = $9;`
+INSERT INTO support_team_permissions("team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone", "use_external_emojis", "use_external_stickers")
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+ON CONFLICT("team_id") DO UPDATE SET "send_messages" = $2, "embed_links" = $3, "attach_files" = $4, "add_reactions" = $5, "send_voice_messages" = $6, "send_tts_messages" = $7, "use_application_commands" = $8, "mention_everyone" = $9, "use_external_emojis" = $10, "use_external_stickers" = $11;`
 
-	_, err := c.Exec(ctx, query, teamId, perms.SendMessages, perms.EmbedLinks, perms.AttachFiles, perms.AddReactions, perms.SendVoiceMessages, perms.SendTTSMessages, perms.UseApplicationCommands, perms.MentionEveryone)
+	_, err := c.Exec(ctx, query, teamId, perms.SendMessages, perms.EmbedLinks, perms.AttachFiles, perms.AddReactions, perms.SendVoiceMessages, perms.SendTTSMessages, perms.UseApplicationCommands, perms.MentionEveryone, perms.UseExternalEmojis, perms.UseExternalStickers)
 	return err
 }
 
@@ -105,7 +113,7 @@ func (c *SupportTeamPermissionsTable) GetForTeams(ctx context.Context, teamIds [
 	}
 
 	query := `
-SELECT "team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone"
+SELECT "team_id", "send_messages", "embed_links", "attach_files", "add_reactions", "send_voice_messages", "send_tts_messages", "use_application_commands", "mention_everyone", "use_external_emojis", "use_external_stickers"
 FROM support_team_permissions
 WHERE "team_id" = ANY($1);`
 
@@ -118,7 +126,7 @@ WHERE "team_id" = ANY($1);`
 	for rows.Next() {
 		var teamId int
 		var perms SupportTeamPermissions
-		if err := rows.Scan(&teamId, &perms.SendMessages, &perms.EmbedLinks, &perms.AttachFiles, &perms.AddReactions, &perms.SendVoiceMessages, &perms.SendTTSMessages, &perms.UseApplicationCommands, &perms.MentionEveryone); err != nil {
+		if err := rows.Scan(&teamId, &perms.SendMessages, &perms.EmbedLinks, &perms.AttachFiles, &perms.AddReactions, &perms.SendVoiceMessages, &perms.SendTTSMessages, &perms.UseApplicationCommands, &perms.MentionEveryone, &perms.UseExternalEmojis, &perms.UseExternalStickers); err != nil {
 			return nil, err
 		}
 		result[teamId] = perms


### PR DESCRIPTION
RM-243

For:
https://github.com/TicketsBot-cloud/worker/pull/118
https://github.com/TicketsBot-cloud/dashboard/pull/95

SQL Query:
```sql
CREATE TABLE IF NOT EXISTS support_team_permissions(
	"team_id" int NOT NULL,
	"add_reactions" bool NOT NULL DEFAULT 't',
	"send_messages" bool NOT NULL DEFAULT 't',
	"send_tts_messages" bool NOT NULL DEFAULT 't',
	"embed_links" bool NOT NULL DEFAULT 't',
	"attach_files" bool NOT NULL DEFAULT 't',
	"mention_everyone" bool NOT NULL DEFAULT 'f',
	"use_external_emojis" bool NOT NULL DEFAULT 't',
	"use_application_commands" bool NOT NULL DEFAULT 't',
	"use_external_stickers" bool NOT NULL DEFAULT 't',
	"send_voice_messages" bool NOT NULL DEFAULT 't',
	FOREIGN KEY("team_id") REFERENCES support_team("id") ON DELETE CASCADE ON UPDATE CASCADE,
	PRIMARY KEY("team_id")
);
```