### PR TITLE
Increase embed column lengths to 256

### DIFF
--- a/embedfields.go
+++ b/embedfields.go
@@ -34,6 +34,8 @@ CREATE TABLE IF NOT EXISTS embed_fields(
 	FOREIGN KEY("embed_id") REFERENCES embeds("id") ON DELETE CASCADE,
 	PRIMARY KEY("id")
 );
+
+ALTER TABLE embed_fields ALTER COLUMN "name" TYPE VARCHAR(256);
 `
 }
 

--- a/embeds.go
+++ b/embeds.go
@@ -59,6 +59,9 @@ CREATE TABLE IF NOT EXISTS embeds(
 	PRIMARY KEY("id")
 );
 CREATE INDEX IF NOT EXISTS embeds_guild_id ON embeds("guild_id");
+
+ALTER TABLE embeds ALTER COLUMN "title" TYPE VARCHAR(256);
+ALTER TABLE embeds ALTER COLUMN "author_name" TYPE VARCHAR(256);
 `
 }
 


### PR DESCRIPTION
The embed title, author_name and fields name have a limit of 256, which currently in the database is 255
https://docs.discord.com/developers/resources/message#embed-object:~:text=should%20display%20inline-,Embed%20Limits,-To%20facilitate%20showing

This is mostly just for the SQL query but it needs to be added in the code too
```sql
ALTER TABLE embed_fields ALTER COLUMN "name" TYPE VARCHAR(256);
ALTER TABLE embeds ALTER COLUMN "title" TYPE VARCHAR(256);
ALTER TABLE embeds ALTER COLUMN "author_name" TYPE VARCHAR(256);
```